### PR TITLE
docs: simplify Codex/OpenClaw README instructions to skill link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is an iPhone using Agent that uses OpenAI models to get things done on a phone, spanning across multiple apps, very similar to a human user. It was built during an OpenAI hackathon last year.
 
-PhoneAgent now also exposes a UI-test JSON-RPC bridge so external AI agents can drive your iPhone directly. In practice, this means tools like **Codex** and **OpenClaw** can inspect the iOS accessibility tree, perform actions, and complete multi-step tasks on device.
+PhoneAgent also exposes a UI-test JSON-RPC bridge so external AI agents can drive your iPhone directly. In practice, this means tools like **Codex** and **OpenClaw** can inspect the iOS accessibility tree, perform actions, and complete multi-step tasks on device.
 
 # Demo
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is an iPhone using Agent that uses OpenAI models to get things done on a phone, spanning across multiple apps, very similar to a human user. It was built during an OpenAI hackathon last year.
 
+PhoneAgent now also exposes a UI-test JSON-RPC bridge so external AI agents can drive your iPhone directly. In practice, this means tools like **Codex** and **OpenClaw** can inspect the iOS accessibility tree, perform actions, and complete multi-step tasks on device.
+
 # Demo
 
 [![image](https://github.com/user-attachments/assets/a25cc506-47a0-4fae-93c4-cf890b236c13)](https://www.youtube.com/shorts/4rnv6dN-2Lg)
@@ -14,6 +16,14 @@ Example prompts:
 - Open Control Center and enable the torch
 
 # RPC Bridge
+
+PhoneAgent can run in **bridge mode** so external agents can control iOS through a newline-delimited JSON-RPC interface.
+
+## Use from Codex / OpenClaw
+
+Have your agent use the PhoneAgent skill in this repo: [`.agents/skills/phoneagent/`](./.agents/skills/phoneagent/).
+
+That skill contains the end-to-end setup and operating workflow for Codex/OpenClaw, including bridge startup, localhost forwarding, RPC methods, and screenshot capture guidance.
 
 You can drive iOS UI via the UI-test JSON-RPC bridge (newline-delimited JSON). See `.agents/skills/phoneagent/SKILL.md` for a full workflow.
 


### PR DESCRIPTION
### Motivation
- Remove duplicated step-by-step bridge instructions from the top-level README and direct agent authors to the PhoneAgent skill folder which contains the canonical, end-to-end setup and operating workflow for Codex/OpenClaw.

### Description
- Replaced the README `## Use from Codex / OpenClaw` subsection with a link to `/.agents/skills/phoneagent/` and a short note that the skill contains bridge startup, localhost forwarding, RPC methods, and screenshot guidance.
- Preserved the helper CLI examples and the security/localhost forwarding notes elsewhere in the RPC Bridge section.

### Testing
- Ran the automated Python replacement script that updated the README block and it completed successfully (`python -c` script printed `updated`).
- Verified the README diff with `git diff -- README.md` and inspected the file with `nl -ba README.md | sed -n '16,40p'` to confirm the new content.
- Committed the change with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ac8194a0832c97012e1831fdba44)