### PR TITLE
Add ping handler to Android RPC bridge

### DIFF
--- a/.agents/skills/phoneagent/scripts/android_rpc_bridge.py
+++ b/.agents/skills/phoneagent/scripts/android_rpc_bridge.py
@@ -410,6 +410,9 @@ class AndroidDeviceBridge:
         if method == "stop":
             return {}, True
 
+        if method == "ping":
+            return {"status": "ok", "pong": True}, False
+
         raise RPCError(f"Unsupported command: {method}")
 
 


### PR DESCRIPTION
### Description
* Adds a `ping` command handler to the Android RPC bridge that returns `{"status": "ok", "pong": true}`. This allows callers to health-check the bridge connection without triggering an unsupported command error.